### PR TITLE
refs #7 Updated pivot for commands handling:

### DIFF
--- a/include/hnz_pivot_filter.hpp
+++ b/include/hnz_pivot_filter.hpp
@@ -112,7 +112,7 @@ private:
     Datapoint* convertTVCACKToPivot(const std::string& assetName, std::map<std::string, bool>& attributeFound,
                                     const GenericDataObject& dataObject, std::shared_ptr<HNZPivotDataPoint> exchangeConfig);
 
-    std::vector<Datapoint*> convertDatapointToHNZ(const std::string& assetName, Datapoint* sourceDp);
+    std::vector<Datapoint*> convertDatapointToHNZ(const std::string& assetName, Datapoint* sourceDp) const;
 
     std::shared_ptr<HNZPivotConfig> m_filterConfig;
     std::recursive_mutex            m_configMutex;

--- a/include/hnz_pivot_filter.hpp
+++ b/include/hnz_pivot_filter.hpp
@@ -93,7 +93,7 @@ private:
     template <class T>
     Datapoint* createDpWithValue(const std::string& name, const T value);
 
-    void convertDatapoint(const std::string& assetName, Datapoint* dp, std::vector<Datapoint*>& convertedDatapoints);
+    bool convertDatapoint(const std::string& assetName, Datapoint* dp, std::vector<Datapoint*>& convertedDatapoints);
 
     template <typename T>
     void static readAttribute(std::map<std::string, bool>& attributeFound, Datapoint* dp,
@@ -112,7 +112,7 @@ private:
     Datapoint* convertTVCACKToPivot(const std::string& assetName, std::map<std::string, bool>& attributeFound,
                                     const GenericDataObject& dataObject, std::shared_ptr<HNZPivotDataPoint> exchangeConfig);
 
-    Datapoint* convertDatapointToHNZ(const std::string& assetName, Datapoint* sourceDp);
+    std::vector<Datapoint*> convertDatapointToHNZ(const std::string& assetName, Datapoint* sourceDp);
 
     std::shared_ptr<HNZPivotConfig> m_filterConfig;
     std::recursive_mutex            m_configMutex;

--- a/include/hnz_pivot_object.hpp
+++ b/include/hnz_pivot_object.hpp
@@ -136,7 +136,7 @@ public:
 
     Datapoint* toDatapoint() {return m_dp;}
 
-    Datapoint* toHnzCommandObject(std::shared_ptr<HNZPivotDataPoint> exchangeConfig);
+    std::vector<Datapoint*> toHnzCommandObject(std::shared_ptr<HNZPivotDataPoint> exchangeConfig);
 
     const std::string& getIdentifier() const {return m_identifier;}
     const std::string& getComingFrom() const {return m_comingFrom;}

--- a/include/hnz_pivot_object.hpp
+++ b/include/hnz_pivot_object.hpp
@@ -136,7 +136,7 @@ public:
 
     Datapoint* toDatapoint() {return m_dp;}
 
-    std::vector<Datapoint*> toHnzCommandObject(std::shared_ptr<HNZPivotDataPoint> exchangeConfig);
+    std::vector<Datapoint*> toHnzCommandObject(std::shared_ptr<HNZPivotDataPoint> exchangeConfig) const;
 
     const std::string& getIdentifier() const {return m_identifier;}
     const std::string& getComingFrom() const {return m_comingFrom;}

--- a/src/hnz_pivot_filter.cpp
+++ b/src/hnz_pivot_filter.cpp
@@ -384,7 +384,7 @@ Datapoint* HNZPivotFilter::convertTVCACKToPivot(const std::string& assetName, st
     return pivot.toDatapoint();
 }
 
-std::vector<Datapoint*> HNZPivotFilter::convertDatapointToHNZ(const std::string& assetName, Datapoint* sourceDp)
+std::vector<Datapoint*> HNZPivotFilter::convertDatapointToHNZ(const std::string& assetName, Datapoint* sourceDp) const
 {
     std::vector<Datapoint*> convertedDatapoints;
     std::string beforeLog = HNZPivotConfig::getPluginName() + " - " + assetName + " - HNZPivotFilter::convertDatapointToHNZ -";

--- a/src/hnz_pivot_object.cpp
+++ b/src/hnz_pivot_object.cpp
@@ -635,11 +635,11 @@ std::vector<Datapoint*> PivotObject::toHnzCommandObject(std::shared_ptr<HNZPivot
     Datapoint* type = createDpWithValue("co_type", exchangeConfig->getTypeId());
     commandObject.push_back(type);
 
-    Datapoint* ca = createDpWithValue("co_addr", static_cast<long>(exchangeConfig->getAddress()));
-    commandObject.push_back(ca);
+    Datapoint* addr = createDpWithValue("co_addr", static_cast<long>(exchangeConfig->getAddress()));
+    commandObject.push_back(addr);
 
-    Datapoint* ioa = createDpWithValue("co_value", intVal);
-    commandObject.push_back(ioa);
+    Datapoint* value = createDpWithValue("co_value", intVal);
+    commandObject.push_back(value);
 
     return commandObject;
 }

--- a/src/hnz_pivot_object.cpp
+++ b/src/hnz_pivot_object.cpp
@@ -265,7 +265,7 @@ Datapoint* PivotObject::getCdc(Datapoint* dp)
             break;
         }
     }
-    if(!unknownChildrenNames.empty()) {
+    if(cdcDp == nullptr) {
         throw PivotObjectException("CDC type unknown: " + PivotUtility::join(unknownChildrenNames));
     }
     
@@ -628,15 +628,18 @@ void PivotObject::addTimestamp(unsigned long doTs, bool doTsS)
     }
 }
 
-Datapoint* PivotObject::toHnzCommandObject(std::shared_ptr<HNZPivotDataPoint> exchangeConfig)
+std::vector<Datapoint*> PivotObject::toHnzCommandObject(std::shared_ptr<HNZPivotDataPoint> exchangeConfig)
 {
-    Datapoint* commandObject = createDp("command_object");
+    std::vector<Datapoint*> commandObject;
 
-    if (commandObject) {
-        addElementWithValue(commandObject, "co_type", exchangeConfig->getTypeId());
-        addElementWithValue(commandObject, "co_addr", static_cast<long>(exchangeConfig->getAddress()));
-        addElementWithValue(commandObject, "co_value", intVal);
-    }
+    Datapoint* type = createDpWithValue("co_type", exchangeConfig->getTypeId());
+    commandObject.push_back(type);
+
+    Datapoint* ca = createDpWithValue("co_addr", static_cast<long>(exchangeConfig->getAddress()));
+    commandObject.push_back(ca);
+
+    Datapoint* ioa = createDpWithValue("co_value", intVal);
+    commandObject.push_back(ioa);
 
     return commandObject;
 }

--- a/src/hnz_pivot_object.cpp
+++ b/src/hnz_pivot_object.cpp
@@ -628,7 +628,7 @@ void PivotObject::addTimestamp(unsigned long doTs, bool doTsS)
     }
 }
 
-std::vector<Datapoint*> PivotObject::toHnzCommandObject(std::shared_ptr<HNZPivotDataPoint> exchangeConfig)
+std::vector<Datapoint*> PivotObject::toHnzCommandObject(std::shared_ptr<HNZPivotDataPoint> exchangeConfig) const
 {
     std::vector<Datapoint*> commandObject;
 


### PR DESCRIPTION
* Commands asset_code is now converted from PivotCommand to HNZCommand.
* Commands in HNZ specific format no longer have a command_object containing all co_* fields.
* Reaings with unknown root object are now forwarded unchanged.
* CDC type in Pivot objects no longer raises unwanted errors if it is not the first element encountered in the Json hierarchy.

Closes #7